### PR TITLE
Added .describe() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ git.tag(__dirname + "node_modules/some-git-repo", function (err, str) {
   // => 0.1.0
 })
 
+git.describe(__dirname + "node_modules/some-git-repo", function (err, str) {
+  console.log('describe', str)
+  // => 0.1.0-22-gf3da3c6
+  // or if no tag exists in the tree, fallback to hash only
+  // => f3da3c6
+})
+
 ```
 
 # Methods
@@ -68,6 +75,9 @@ return the result of `git rev-parse HEAD`
 
 ### .tag([dir,] function (err, tag) { ... })
 return the current tag
+
+### .describe([dir,] function (err, desc) { ... })
+return the result of `git describe --tags --always`
 
 ### .branch([dir,] function (err, branch) { ... })
 return the current branch

--- a/example/simple.js
+++ b/example/simple.js
@@ -20,6 +20,13 @@ git.tag(function (err, str) {
   // => 0.1.0
 })
 
+git.describe(function (err, str) {
+  console.log('describe', str)
+  // => 0.1.0-22-g2ea34b
+  // or if no tag was found, fallback to hash
+  // => 2ea34b
+})
+
 git.log(function (err, array) {
   console.log('log', array)
   // [ [ 'aefdd946ea65c88f8aa003e46474d57ed5b291d1',

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
   , long : _command.bind(null, 'git rev-parse HEAD')
   , branch : _command.bind(null, 'git rev-parse --abbrev-ref HEAD')
   , tag : _command.bind(null, 'git describe --always --tag --abbrev=0')
+  , describe : _command.bind(null, 'git describe --tags --always')
   , log : function (dir, cb) {
       if (typeof dir === 'function') cb = dir, dir = __dirname
       _command('git log --no-color --pretty=format:\'[ "%H", "%s", "%cr", "%an" ],\' --abbrev-commit', dir, function (err, str) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url" : "git://github.com/yanatan16/git-rev.git"
   },
   "homepage" : "https://github.com/yanatan16/git-rev",
-  "keywords" : [ "git", "revision", "tag", "hash", "short-hash", "branch", "git-log" ],
+  "keywords" : [ "git", "revision", "tag", "describe", "hash", "short-hash", "branch", "git-log" ],
   "authors" : [
     {
       "name" : "Thomas Blobaum",


### PR DESCRIPTION
Perfect for creating uniquely named tarballs for any commit while still maintaining readability with tag names.
